### PR TITLE
add option for extensions to define their own explicit jwt type

### DIFF
--- a/draft-jones-oauth-rfc7523bis.xml
+++ b/draft-jones-oauth-rfc7523bis.xml
@@ -353,8 +353,9 @@
 	<t>
 	  Authorization grant JWTs MUST be explicitly typed by using the
 	  <spanx style="verb">typ</spanx> header parameter value
-	  <spanx style="verb">authorization-grant+jwt</spanx>.
-	  Authorization grant JWTs not using this explicit type value
+	  <spanx style="verb">authorization-grant+jwt</spanx> or
+    an extension-defined type.
+	  Authorization grant JWTs not using the explicit type value
 	  MUST be rejected by the authorization server.
 	</t>
 	<t>
@@ -394,8 +395,9 @@
 	<t>
 	  Client authentication JWTs MUST be explicitly typed by using the
 	  <spanx style="verb">typ</spanx> header parameter value
-	  <spanx style="verb">client-authentication+jwt</spanx>.
-	  Client authentication JWTs not using this explicit type value
+	  <spanx style="verb">client-authentication+jwt</spanx>
+    or an extension-defined type.
+	  Client authentication JWTs not using the explicit type value
 	  MUST be rejected by the authorization server.
 	</t>
 	<t>If the client JWT is not valid, the

--- a/draft-jones-oauth-rfc7523bis.xml
+++ b/draft-jones-oauth-rfc7523bis.xml
@@ -354,7 +354,7 @@
 	  Authorization grant JWTs MUST be explicitly typed by using the
 	  <spanx style="verb">typ</spanx> header parameter value
 	  <spanx style="verb">authorization-grant+jwt</spanx> or
-    an extension-defined type.
+	  another more specific explicit type value defined by a specification profiling this specification.
 	  Authorization grant JWTs not using the explicit type value
 	  MUST be rejected by the authorization server.
 	</t>

--- a/draft-jones-oauth-rfc7523bis.xml
+++ b/draft-jones-oauth-rfc7523bis.xml
@@ -396,7 +396,7 @@
 	  Client authentication JWTs MUST be explicitly typed by using the
 	  <spanx style="verb">typ</spanx> header parameter value
 	  <spanx style="verb">client-authentication+jwt</spanx>
-    or an extension-defined type.
+	  another more specific explicit type value defined by a specification profiling this specification.
 	  Client authentication JWTs not using the explicit type value
 	  MUST be rejected by the authorization server.
 	</t>


### PR DESCRIPTION
See [Identity Assertion Authorization Grant](https://datatracker.ietf.org/doc/draft-parecki-oauth-identity-assertion-authz-grant/) for an example of an extension that defines its own JWT type for the authorization grant defined in the extension.